### PR TITLE
Cache fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
   group = 'io.michaelrocks'
-  version = '0.3.5'
+  version = '0.3.6'
 
   ext.javaVersion = JavaVersion.VERSION_1_8
   ext.kotlinVersion = '1.5.20'

--- a/gradle-plugin/src/main/java/io/michaelrocks/paranoid/plugin/ParanoidTransform.kt
+++ b/gradle-plugin/src/main/java/io/michaelrocks/paranoid/plugin/ParanoidTransform.kt
@@ -111,6 +111,10 @@ class ParanoidTransform(
     return false
   }
 
+  override fun isCacheable(): Boolean {
+    return true
+  }
+
   override fun getParameterInputs(): MutableMap<String, Any?> {
     return mutableMapOf(
       "version" to Build.VERSION,

--- a/processor/src/main/kotlin/io/michaelrocks/paranoid/processor/DeobfuscatorGenerator.kt
+++ b/processor/src/main/kotlin/io/michaelrocks/paranoid/processor/DeobfuscatorGenerator.kt
@@ -19,8 +19,6 @@ package io.michaelrocks.paranoid.processor
 import io.michaelrocks.grip.ClassRegistry
 import io.michaelrocks.grip.mirrors.toAsmType
 import io.michaelrocks.paranoid.processor.model.Deobfuscator
-import jdk.internal.org.objectweb.asm.Opcodes.ACC_PUBLIC
-import jdk.internal.org.objectweb.asm.Opcodes.ACC_SUPER
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes
@@ -37,7 +35,7 @@ class DeobfuscatorGenerator(
     val writer = StandaloneClassWriter(ClassWriter.COMPUTE_MAXS or ClassWriter.COMPUTE_FRAMES, classRegistry)
     writer.visit(
       Opcodes.V1_6,
-      ACC_PUBLIC or ACC_SUPER,
+      Opcodes.ACC_PUBLIC or Opcodes.ACC_SUPER,
       deobfuscator.type.internalName,
       null,
       OBJECT_TYPE.internalName,


### PR DESCRIPTION
1. Declare ParandoidTransform cacheable
2. Reset file timestamps at jar creation. results of transform now byte-to-byte identical for identical inputs