### PR TITLE
Add settings to apply paranoid only to specific build types

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ paranoid {
 ```
 
 The extension object contains the following properties:
-- `enabled` — `boolean`. Allows to disable obfuscation for the project. Default value is `true`.
 - `cacheable` — `boolean`. Allows to enable caching for the transform. Default value is `false`.
 - `includeSubprojects` — `boolean`. Allows to enable obfuscation for subprojects. Default value is `false`.
 - `obfuscationSeed` - `Integer`. A seed that can be used to make obfuscation stable across builds. Default value is `null`, which means that the seed
   is computed from input files on each build.
+- `applyToBuildTypes` - Allows to apply paranoid transform for specific build types. Possible values are `'ALL'`, `'NONE'`, `'NOT_DEBUGGABLE'`. Default value is `'ALL'`
+- `enabled` — `boolean`. Allows to disable obfuscation for the project. Default value is `true`. *Deprecated*. Use `applyToBuildTypes = 'NONE'`
 
 How it works
 ------------

--- a/gradle-plugin/src/main/java/io/michaelrocks/paranoid/plugin/ParanoidExtension.kt
+++ b/gradle-plugin/src/main/java/io/michaelrocks/paranoid/plugin/ParanoidExtension.kt
@@ -16,9 +16,25 @@
 
 package io.michaelrocks.paranoid.plugin
 
+import io.michaelrocks.paranoid.processor.logging.getLogger
+
 open class ParanoidExtension {
+  @Deprecated(IS_ENABLED_DEPRECATION_WARNING)
   var isEnabled: Boolean = true
+    set(value) {
+      getLogger().warn("WARNING: $IS_ENABLED_DEPRECATION_WARNING")
+      field = value
+    }
   var isCacheable: Boolean = false
   var includeSubprojects: Boolean = false
   var obfuscationSeed: Int? = null
+  var applyToBuildTypes: BuildType = BuildType.ALL
 }
+
+enum class BuildType {
+  NONE,
+  ALL,
+  NOT_DEBUGGABLE
+}
+
+private const val IS_ENABLED_DEPRECATION_WARNING = "paranoid.enabled is deprecated. Use paranoid.applyToBuildTypes"


### PR DESCRIPTION
Added config param `applyToBuildTypes` to switch off transform for specific build types.
Possible values are: 
ALL - add transforms for all build types
NOT_DEBBUGABLE - add transforms only for build types with debuggable = false (release build type in most cases)
NONE - Do not add transforms at all. 

`applyToBuildTypes = 'NONE'` works exactly as `enabled = false`

Added deprecation warning to build log if `enabled` is used. 